### PR TITLE
Use :provided profile to really fix #1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,4 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
   :global-vars {*warn-on-reflection* true}
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-log4j12 "1.7.25" :scope "runtime"]]}})
+  :profiles {:provided {:dependencies [[org.slf4j/slf4j-log4j12 "1.7.25"]]}})

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,4 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
   :global-vars {*warn-on-reflection* true}
-  :profiles {:provided {:dependencies [[org.slf4j/slf4j-log4j12 "1.7.25"]]}})
+  :profiles {:dev {:dependencies [[org.slf4j/slf4j-log4j12 "1.7.25"]]}})


### PR DESCRIPTION
Pr #2 doesn't have the expected effect, the dependencies of :dev profile are added to the generated pom.xml project descriptor. The content of :provided profile is added too, but scoped as "provided". It's a bit hacky but does the work.

For more details about dependency scopes, see https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope